### PR TITLE
feat: migrate from ECS direct deploy to CodeDeploy blue/green

### DIFF
--- a/appspec.yaml
+++ b/appspec.yaml
@@ -1,0 +1,9 @@
+version: 1
+Resources:
+  - TargetService:
+      Type: AWS::ECS::Service
+      Properties:
+        TaskDefinition: taskdef.json
+        LoadBalancerInfo:
+          ContainerName: "blacklist-container"
+          ContainerPort: 8080

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,7 +30,7 @@ phases:
         if [ ! -f "${PROJECT_DIR}/.env" ] && [ -f "${PROJECT_DIR}/.env.example" ]; then
           cp "${PROJECT_DIR}/.env.example" "${PROJECT_DIR}/.env"
         fi
-      - export PYTHONPATH="${PWD}/${PROJECT_DIR}/src:${PYTHONPATH}"
+      - export PYTHONPATH="${PWD}/${PROJECT_DIR}/src:${PYTHONPATH}}"
       - python -m pytest -q ${UNIT_TESTS_DIR} || exit 1
 
       - echo "Autenticando en Amazon ECR..."
@@ -47,11 +47,48 @@ phases:
     commands:
       - echo "Subiendo imagen a ECR..."
       - docker push ${REPO_URI}:${IMAGE_TAG}
-      - echo "Creando imagedefinitions.json para ECS..."
-      - printf '[{"name":"%s","imageUri":"%s"}]' ${CONTAINER_NAME} ${REPO_URI}:${IMAGE_TAG} > imagedefinitions.json
-      - echo "Build y push completado exitosamente."
+
+      - echo "Creando taskdef.json para CodeDeploy..."
+      - |
+        cat <<EOF > taskdef.json
+        {
+          "family": "blacklist",
+          "networkMode": "awsvpc",
+          "requiresCompatibilities": ["FARGATE"],
+          "cpu": "256",
+          "memory": "512",
+          "containerDefinitions": [
+            {
+              "name": "${CONTAINER_NAME}",
+              "image": "${REPO_URI}:${IMAGE_TAG}",
+              "essential": true,
+              "portMappings": [
+                {
+                  "containerPort": 8080,
+                  "protocol": "tcp"
+                }
+              ]
+            }
+          ]
+        }
+        EOF
+
+      - echo "Creando appspec.yaml para CodeDeploy..."
+      - |
+        cat <<EOF > appspec.yaml
+        version: 1
+        Resources:
+          - TargetService:
+              Type: AWS::ECS::Service
+              Properties:
+                TaskDefinition: taskdef.json
+                LoadBalancerInfo:
+                  ContainerName: "${CONTAINER_NAME}"
+                  ContainerPort: 8080
+        EOF
 
 artifacts:
   files:
-    - imagedefinitions.json
+    - appspec.yaml
+    - taskdef.json
   discard-paths: yes

--- a/taskdef.json
+++ b/taskdef.json
@@ -1,0 +1,20 @@
+{
+  "family": "blacklist",
+  "containerDefinitions": [
+    {
+      "name": "blacklist-container",
+      "image": "<IMAGE_URI_FROM_CODEBUILD>",
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true
+    }
+  ],
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "cpu": "256",
+  "memory": "512"
+}


### PR DESCRIPTION
- Replaced imagedefinitions.json with taskdef.json and appspec.yaml for CodeDeploy integration
- Added Fargate task definition with network mode, CPU/memory limits, and container configuration
- Configured container port mapping to expose service on port 8080
- Fixed PYTHONPATH environment variable syntax in build phase
- Updated artifacts section to include new deployment configuration files