### PR TITLE
feat: enhance deployment configuration with logging and validation

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -48,6 +48,9 @@ phases:
       - echo "Subiendo imagen a ECR..."
       - docker push ${REPO_URI}:${IMAGE_TAG}
 
+      - echo "Creando CloudWatch Log Group si no existe..."
+      - aws logs create-log-group --log-group-name "/ecs/blacklist" --region ${REGION} || echo "Log group ya existe"
+
       - echo "Creando taskdef.json para CodeDeploy..."
       - |
         cat <<EOF > taskdef.json
@@ -85,7 +88,7 @@ phases:
 
       - echo "Creando appspec.yaml para CodeDeploy..."
       - |
-        cat <<EOF > appspec.yaml
+        cat > appspec.yaml << 'EOF'
         version: 0.0
         Resources:
           - TargetService:
@@ -93,9 +96,25 @@ phases:
               Properties:
                 TaskDefinition: <TASK_DEFINITION>
                 LoadBalancerInfo:
-                  ContainerName: "${CONTAINER_NAME}"
+                  ContainerName: "blacklist-container"
                   ContainerPort: 8080
+        Hooks:
+          - BeforeInstall: "scripts/stop_application"
+          - AfterInstall: "scripts/start_application"
+          - ApplicationStart: "scripts/start_application"
+          - ApplicationStop: "scripts/stop_application"
         EOF
+
+      - echo "Haciendo scripts ejecutables..."
+      - chmod +x scripts/*
+
+      - echo "Validando archivos generados..."
+      - echo "=== taskdef.json ==="
+      - cat taskdef.json
+      - echo "=== appspec.yaml ==="
+      - cat appspec.yaml
+      - echo "Validando JSON..."
+      - python -m json.tool taskdef.json > /dev/null && echo "✅ taskdef.json válido" || (echo "❌ taskdef.json inválido" && exit 1)
 
 artifacts:
   files:


### PR DESCRIPTION
- Added CloudWatch log group creation for "/ecs/blacklist" with region-specific configuration
- Updated appspec.yaml with deployment lifecycle hooks for application start/stop scripts
- Added file validation steps to verify taskdef.json and appspec.yaml integrity
- Made deployment scripts executable with chmod
- Fixed container name reference in appspec.yaml to use static "blacklist-container"
- Added debug output to display generate