### PR TITLE
refactor: simplify deployment hooks in buildspec.yml

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -99,10 +99,7 @@ phases:
                   ContainerName: "blacklist-container"
                   ContainerPort: 8080
         Hooks:
-          - BeforeInstall: "scripts/stop_application"
-          - AfterInstall: "scripts/start_application"
-          - ApplicationStart: "scripts/start_application"
-          - ApplicationStop: "scripts/stop_application"
+          - AfterAllowTestTraffic: "scripts/start_application"
         EOF
 
       - echo "Haciendo scripts ejecutables..."


### PR DESCRIPTION
- Removed redundant BeforeInstall, ApplicationStart, and ApplicationStop hooks
- Consolidated deployment process to use single AfterAllowTestTraffic hook
- Kept only essential "scripts/start_application" execution point
- Streamlined container deployment flow to reduce complexity and potential failure points