### PR TITLE
refactor: convert appspec config from YAML to JSON format

### DIFF
--- a/appspec.json
+++ b/appspec.json
@@ -1,0 +1,17 @@
+{
+  "version": 0.0,
+  "Resources": [
+    {
+      "TargetService": {
+        "Type": "AWS::ECS::Service",
+        "Properties": {
+          "TaskDefinition": "<TASK_DEFINITION>",
+          "LoadBalancerInfo": {
+            "ContainerName": "blacklist-container",
+            "ContainerPort": 8080
+          }
+        }
+      }
+    }
+  ]
+}

--- a/appspec.yaml
+++ b/appspec.yaml
@@ -1,9 +1,0 @@
-version: 0.0
-Resources:
-  - TargetService:
-      Type: AWS::ECS::Service
-      Properties:
-        TaskDefinition: <TASK_DEFINITION>
-        LoadBalancerInfo:
-          ContainerName: blacklist-container
-          ContainerPort: 8080

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -57,12 +57,13 @@ phases:
       - echo "Validando archivos generados..."
       - echo "=== taskdef.json ==="
       - cat taskdef.json
-      - echo "=== appspec.yaml ==="
-      - cat appspec.yaml
+      - echo "=== appspec.json ==="
+      - cat appspec.json
       - echo "Validando JSON..."
       - python -m json.tool taskdef.json > /dev/null && echo "✅ taskdef.json válido" || (echo "❌ taskdef.json inválido" && exit 1)
+      - python -m json.tool appspec.json > /dev/null && echo "✅ appspec.json válido" || (echo "❌ appspec.json inválido" && exit 1)
 
 artifacts:
   files:
-    - appspec.yaml
+    - appspec.json
     - taskdef.json


### PR DESCRIPTION
- Replaced appspec.yaml with equivalent appspec.json for consistent JSON usage across config files
- Updated buildspec.yml to reference appspec.json instead of appspec.yaml in validation and artifacts
- Added JSON validation check for appspec.json in build pipeline
- Maintained same ECS service configuration content while changing only the file format