### PR TITLE
feat: update ECS task definition family name

### DIFF
--- a/taskdef.json
+++ b/taskdef.json
@@ -1,5 +1,5 @@
 {
-  "family": "blacklist",
+  "family": "blacklist-v2",
   "executionRoleArn": "arn:aws:iam::982590066260:role/ecsTaskExecutionRole",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],


### PR DESCRIPTION
- Changed task definition family from "blacklist" to "blacklist-v2" to support new deployment version
- Maintained existing Fargate configuration and IAM execution role settings